### PR TITLE
fix: OneBot适配器下引用消息图片获取异常

### DIFF
--- a/src/models/Meme/index.ts
+++ b/src/models/Meme/index.ts
@@ -41,13 +41,15 @@ export async function make (
 ): Promise<any> {
   const formData = new FormData()
 
-  const quotedUser = e.elements.find((msg) => msg.type === 'reply') && e.userId
+  const quotedUser = e.elements.some(msg => msg?.type === 'reply') ? e.userId : null
   const allUsers = [
     ...new Set([
-      ...e.elements.filter(m => m.type === 'at').map(at => at.targetId.toString()),
-      ...[...(userText?.matchAll(/@\s*(\d+)/g) ?? [])].map(match => match[1])
+      ...(e.elements.some(m => m?.type === 'reply')
+        ? []
+        : e.elements.filter(m => m?.type === 'at').map(at => at?.targetId?.toString() ?? '')),
+      ...[...(userText?.matchAll(/@\s*(\d+)/g) ?? [])].map(match => match[1] ?? '')
     ])
-  ].filter(targetId => targetId !== quotedUser)
+  ].filter(targetId => targetId && targetId !== quotedUser)
 
   if (userText) {
     userText = userText.replace(/@\s*\d+/g, '').trim()


### PR DESCRIPTION
- 改进 quotedUser 的判断逻辑
- 优化 allUsers 数组的构建过程，考虑回复用户的情况

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 修复了 OneBot 适配器中无法检索引用消息图片的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where quoted message images could not be retrieved in the OneBot adapter.

</details>